### PR TITLE
🦉 enable/disable KV cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -164,3 +164,5 @@ cython_debug/
 assets/llama*
 assets/*.model
 assets/pytorch-llama
+
+test*

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ I am reading these papers:
 ✅ Understand and implement the concept of Llama2 architecture.  
 ✅ Test the Llama2 implementation using the checkpoints from Meta.  
 ✅ Download the checkpoints of Llama2 and inspect the inference code and working.  
-☑️ Documentation of the Llama2 implementation and repo. 
+☑️ Documentation of the Llama2 implementation and repo.  
+☑️ Work on implementation of enabling and disabling the KV cache. 
 
 
 ### **Blog Posts:**  

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ I am reading these papers:
 ✅ Test the Llama2 implementation using the checkpoints from Meta.  
 ✅ Download the checkpoints of Llama2 and inspect the inference code and working.  
 ☑️ Documentation of the Llama2 implementation and repo.  
-☑️ Work on implementation of enabling and disabling the KV cache. 
+✅ Work on implementation of enabling and disabling the KV cache.  
+✅ Add the attention mask when disabling the KV cache in Llama2.
 
 
 ### **Blog Posts:**  

--- a/llama/inference.py
+++ b/llama/inference.py
@@ -62,17 +62,19 @@ class LlamaInference(nn.Module):
         eos_reached = torch.tensor([False] * batch_size, device=self.args.device)
         prompt_token_mask = (
             tokens != pad_id
-        )  # true for prompt tokens, false for pad tokens
+        )  # true for prompt tokens, false for pad tokens.
         cur_iterator = tqdm(range(1, total_len), desc="Generating tokens")
 
         for cur_pos in cur_iterator:
             with torch.no_grad():
                 if self.args.use_cache:
-                    # use KV cache for faster inference
+                    # use KV cache for faster inference.
                     logits = self.model.forward(
                         tokens[:, cur_pos - 1 : cur_pos], cur_pos, None
                     )
                 else:
+                    # the current position is optional in this case.
+                    # we will use positional encoding to the entire sequence.
                     logits = self.model.forward(tokens[:, :cur_pos], cur_pos, None)
 
             if temperature > 0:
@@ -129,7 +131,7 @@ if __name__ == "__main__":
     checkpoints = "/home/ubuntu/bin/Meta-llama/assets"
 
     prompts = [
-        "The quick brown fox jumps ",
+        "I believe",
     ]
 
     llama = Llama.build(
@@ -144,7 +146,7 @@ if __name__ == "__main__":
 
     model = LlamaInference(llama.model, llama.tokenizer, llama.args)
 
-    out_tokens, out_text = model.text_completion(prompts, max_gen_len=256)
+    out_tokens, out_text = model.text_completion(prompts, max_gen_len=20, temperature=0)
     assert len(out_text) == len(prompts)
     for i in range(len(out_text)):
         print(out_text[i])

--- a/llama/llama2.py
+++ b/llama/llama2.py
@@ -299,7 +299,9 @@ class GroupedQueryAttentionLLAMA(nn.Module):
         )
 
         if mask is not None:
-            attention_scores = attention_scores.masked_fill_(mask == 0, -1e9)
+            attention_scores = attention_scores.masked_fill_(
+                mask == 0, value=float("-inf")
+            )
         # (batch_size, n_heads, seq_len, seq_len_kv) --> (batch_size, n_heads, seq_len, seq_len_kv)
         attention_scores = F.softmax(attention_scores.float(), dim=-1).type_as(query)
         # (batch_size, n_heads, seq_len, seq_len_kv) @ (batch_size, n_heads, seq_len_kv, head_dim) --> (batch_size, n_heads, seq_len, head_dim)


### PR DESCRIPTION
1. Is the update for enabling and disabling the KV cache correct? In the inference, we are passing the `tokens up to the current position` & in Grouped Query Attention, we are directly passing the `Keys & Values`. 